### PR TITLE
feature: 메인 뉴스 및 상세 뉴스 API 연동

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -134,6 +134,10 @@ android {
         // image url
         implementation(libs.coil.compose)
 
+        // custom tab
+        implementation("androidx.browser:browser:1.8.0")
+
+
     }
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -130,6 +130,10 @@ android {
         implementation("androidx.compose.ui:ui-graphics")
         implementation("androidx.compose.ui:ui-tooling-preview")
         implementation("androidx.compose.material3:material3")
+
+        // image url
+        implementation(libs.coil.compose)
+
     }
 }
 

--- a/app/src/main/java/com/example/mz_focusnews/core/api/ApiResponse.kt
+++ b/app/src/main/java/com/example/mz_focusnews/core/api/ApiResponse.kt
@@ -1,0 +1,8 @@
+package com.example.mz_focusnews.core.api
+
+data class ApiResponse<T>(
+    val success: Boolean,
+    val status: Int,
+    val msg: String,
+    val data: T
+)

--- a/app/src/main/java/com/example/mz_focusnews/core/api/model/BreakingNews.kt
+++ b/app/src/main/java/com/example/mz_focusnews/core/api/model/BreakingNews.kt
@@ -1,0 +1,11 @@
+package com.example.mz_focusnews.core.api.model
+
+data class BreakingNews(
+    val breakingNewsRecent: BreakingItem,
+    val breakingNews: List<BreakingItem>
+)
+
+data class BreakingItem(
+    val id: Long,
+    val title: String
+)

--- a/app/src/main/java/com/example/mz_focusnews/core/api/model/News.kt
+++ b/app/src/main/java/com/example/mz_focusnews/core/api/model/News.kt
@@ -1,0 +1,9 @@
+package com.example.mz_focusnews.core.api.model
+
+data class News(
+    val id: Long,
+    val title: String,
+    val content: String,
+    val date: String,
+    val imgUrl: String
+)

--- a/app/src/main/java/com/example/mz_focusnews/core/api/model/NewsDetail.kt
+++ b/app/src/main/java/com/example/mz_focusnews/core/api/model/NewsDetail.kt
@@ -1,0 +1,9 @@
+package com.example.mz_focusnews.core.api.model
+
+data class NewsDetail(
+    val id: Long,
+    val title: String,
+    val summary: String,
+    val imgUrl: String,
+    val link: String
+)

--- a/app/src/main/java/com/example/mz_focusnews/core/api/model/NewsGroup.kt
+++ b/app/src/main/java/com/example/mz_focusnews/core/api/model/NewsGroup.kt
@@ -1,0 +1,8 @@
+package com.example.mz_focusnews.core.api.model
+
+// 오늘. 이주. 이달의 뉴스
+data class NewsGroup(
+    val week: News,
+    val month: News,
+    val day: News
+)

--- a/app/src/main/java/com/example/mz_focusnews/core/api/service/ApiService.kt
+++ b/app/src/main/java/com/example/mz_focusnews/core/api/service/ApiService.kt
@@ -1,6 +1,7 @@
 package com.example.mz_focusnews.core.api.service
 
 import com.example.mz_focusnews.core.api.ApiResponse
+import com.example.mz_focusnews.core.api.model.BreakingNews
 import com.example.mz_focusnews.core.api.model.NewsDetail
 import com.example.mz_focusnews.core.api.model.NewsGroup
 import retrofit2.http.GET
@@ -12,5 +13,8 @@ interface ApiService {
 
     @GET("user/v1/newsDetails")
     suspend fun getNewsDetail(@Query("newsId") newsId: Long): ApiResponse<NewsDetail>
+
+    @GET("user/v1/main/breakingNews")
+    suspend fun getBreakingNews(): ApiResponse<BreakingNews>
 }
 

--- a/app/src/main/java/com/example/mz_focusnews/core/api/service/ApiService.kt
+++ b/app/src/main/java/com/example/mz_focusnews/core/api/service/ApiService.kt
@@ -1,0 +1,16 @@
+package com.example.mz_focusnews.core.api.service
+
+import com.example.mz_focusnews.core.api.ApiResponse
+import com.example.mz_focusnews.core.api.model.NewsDetail
+import com.example.mz_focusnews.core.api.model.NewsGroup
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface ApiService {
+    @GET("user/v1/main/news")
+    suspend fun getMainNewsData(): ApiResponse<NewsGroup>
+
+    @GET("user/v1/newsDetails")
+    suspend fun getNewsDetail(@Query("newsId") newsId: Long): ApiResponse<NewsDetail>
+}
+

--- a/app/src/main/java/com/example/mz_focusnews/core/api/service/RetrofitClient.kt
+++ b/app/src/main/java/com/example/mz_focusnews/core/api/service/RetrofitClient.kt
@@ -1,0 +1,19 @@
+package com.example.mz_focusnews.core.api.service
+
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+object RetrofitClient {
+    private var instance: Retrofit? = null
+    private const val BASE_URL = "http://43.201.188.7:8080/"
+
+    fun getInstance(): Retrofit {
+        if (instance == null) {
+            instance = Retrofit.Builder()
+                .baseUrl(BASE_URL)
+                .addConverterFactory(GsonConverterFactory.create())
+                .build()
+        }
+        return instance!!
+    }
+}

--- a/app/src/main/java/com/example/mz_focusnews/core/components/BottomNavBar.kt
+++ b/app/src/main/java/com/example/mz_focusnews/core/components/BottomNavBar.kt
@@ -15,6 +15,10 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
+import com.example.mz_focusnews.core.components.BottomNavItem.Category
+import com.example.mz_focusnews.core.components.BottomNavItem.Home
+import com.example.mz_focusnews.core.components.BottomNavItem.MyPage
+import com.example.mz_focusnews.core.components.BottomNavItem.Quiz
 import com.example.mz_focusnews.core.theme.Bg_Blue
 import com.example.mz_focusnews.core.theme.Blue_900
 import com.example.mz_focusnews.core.theme.Gray_300
@@ -24,10 +28,10 @@ fun BottomNavBar(
     navController: NavHostController
 ) {
     val items = listOf(
-        BottomNavItem.Home,
-        BottomNavItem.Category,
-        BottomNavItem.Quiz,
-        BottomNavItem.MyPage
+        Home,
+        Category,
+        Quiz,
+        MyPage
     )
     BottomNavigation(
         modifier = Modifier

--- a/app/src/main/java/com/example/mz_focusnews/core/components/BottomNavItem.kt
+++ b/app/src/main/java/com/example/mz_focusnews/core/components/BottomNavItem.kt
@@ -6,15 +6,6 @@ import com.example.mz_focusnews.core.theme.myiconpack.Home
 import com.example.mz_focusnews.core.theme.myiconpack.Quiz
 import com.example.mz_focusnews.core.theme.myiconpack.User
 
-sealed class ScreenRoute(val route: String) {
-    object Content : ScreenRoute("content/{newsId}")
-    object Like : ScreenRoute("like")
-    object Recent : ScreenRoute("recent")
-    object QuizIntro : ScreenRoute("quiz_intro")
-    object QuizPlay : ScreenRoute("quiz_play")
-    object Ranking : ScreenRoute("ranking")
-}
-
 sealed class BottomNavItem(
     val title: String,
     val icon: androidx.compose.ui.graphics.vector.ImageVector,

--- a/app/src/main/java/com/example/mz_focusnews/core/components/BreakingDrawer.kt
+++ b/app/src/main/java/com/example/mz_focusnews/core/components/BreakingDrawer.kt
@@ -16,12 +16,19 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.example.mz_focusnews.core.api.model.BreakingItem
 import com.example.mz_focusnews.core.theme.Blue_300
 import com.example.mz_focusnews.core.theme.preFontFamily
 
 @Composable
-fun DrawerScreen() {
-    val notiList = List(10) { "$it 번째 속보입니다" }
+fun DrawerScreen(
+    onDrawerClosed: () -> Unit,
+    breakingNews: List<BreakingItem>,
+    navigateToContent: (id: Long) -> Unit
+) {
+    if (breakingNews.isEmpty()) {
+        return
+    }
 
     Surface(
         modifier = Modifier
@@ -44,24 +51,31 @@ fun DrawerScreen() {
                     fontSize = 20.sp
                 )
             )
-
-            Column(
-                modifier = Modifier
-                    .background(Color.White)
-                    .padding(top = 20.dp),
-                verticalArrangement = Arrangement.spacedBy(12.dp)
-            ) {
-                notiList.forEach() { noti ->
-                    RoundedCornerBox(radius = 12.dp, bgColor = Blue_300) {
-                        Text(
-                            modifier = Modifier.fillMaxWidth(),
-                            text = noti,
-                            style = TextStyle(
-                                fontFamily = preFontFamily,
-                                fontWeight = FontWeight.SemiBold,
-                                fontSize = 15.sp
-                            ),
-                        )
+            breakingNews.let { news ->
+                Column(
+                    modifier = Modifier
+                        .background(Color.White)
+                        .padding(top = 20.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    news.forEach { item ->
+                        RoundedCornerBox(
+                            radius = 12.dp,
+                            bgColor = Blue_300,
+                            onClick = {
+                                navigateToContent(item.id)
+                                onDrawerClosed()
+                            }) {
+                            Text(
+                                modifier = Modifier.fillMaxWidth(),
+                                text = item.title,
+                                style = TextStyle(
+                                    fontFamily = preFontFamily,
+                                    fontWeight = FontWeight.SemiBold,
+                                    fontSize = 15.sp
+                                ),
+                            )
+                        }
                     }
                 }
             }
@@ -72,5 +86,5 @@ fun DrawerScreen() {
 @Preview
 @Composable
 fun BreakingDrawerPreview() {
-    DrawerScreen()
+    DrawerScreen({ }, listOf()) { }
 }

--- a/app/src/main/java/com/example/mz_focusnews/core/components/RoundedCornerBox.kt
+++ b/app/src/main/java/com/example/mz_focusnews/core/components/RoundedCornerBox.kt
@@ -17,13 +17,16 @@ fun RoundedCornerBox(
     radius: Dp,
     paddingHorizontal: Dp = 18.dp,
     paddingVertical: Dp = 18.dp,
-    bgColor: Color, content: @Composable () -> Unit
+    bgColor: Color,
+    onClick: () -> Unit = { },
+    content: @Composable () -> Unit
 ) {
     Box(
         modifier = Modifier
             .clip(RoundedCornerShape(radius))
             .background(bgColor)
             .padding(horizontal = paddingHorizontal, vertical = paddingVertical)
+            .clickable { onClick() }
     ) {
         content()
     }

--- a/app/src/main/java/com/example/mz_focusnews/core/components/ScreenRoute.kt
+++ b/app/src/main/java/com/example/mz_focusnews/core/components/ScreenRoute.kt
@@ -6,6 +6,15 @@ import com.example.mz_focusnews.core.theme.myiconpack.Home
 import com.example.mz_focusnews.core.theme.myiconpack.Quiz
 import com.example.mz_focusnews.core.theme.myiconpack.User
 
+sealed class ScreenRoute(val route: String) {
+    object Content : ScreenRoute("content/{newsId}")
+    object Like : ScreenRoute("like")
+    object Recent : ScreenRoute("recent")
+    object QuizIntro : ScreenRoute("quiz_intro")
+    object QuizPlay : ScreenRoute("quiz_play")
+    object Ranking : ScreenRoute("ranking")
+}
+
 sealed class BottomNavItem(
     val title: String,
     val icon: androidx.compose.ui.graphics.vector.ImageVector,

--- a/app/src/main/java/com/example/mz_focusnews/core/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/mz_focusnews/core/navigation/NavGraph.kt
@@ -8,7 +8,6 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import com.example.mz_focusnews.core.components.BottomNavItem
-import com.example.mz_focusnews.core.components.ScreenRoute
 import com.example.mz_focusnews.feature.category.CategoryScreen
 import com.example.mz_focusnews.feature.content.ContentScreen
 import com.example.mz_focusnews.feature.content.ContentViewModel
@@ -23,11 +22,10 @@ import com.example.mz_focusnews.feature.quiz.RankingScreen
 import com.example.mz_focusnews.feature.recent.RecentNewsScreen
 
 @Composable
-fun NavGraph(navController: NavHostController, onDrawerOpen: () -> Unit) {
+fun NavGraph(navController: NavHostController, homeViewModel: HomeViewModel, onDrawerOpen: () -> Unit) {
     NavHost(navController = navController, startDestination = BottomNavItem.Home.route) {
         composable(BottomNavItem.Home.route) {
-            val viewModel: HomeViewModel = viewModel()  // 직접 ViewModel 생성
-            HomeScreen(viewModel, navController, onDrawerOpen)
+            HomeScreen(homeViewModel, navController, onDrawerOpen)
         }
 
         composable(BottomNavItem.Category.route) {

--- a/app/src/main/java/com/example/mz_focusnews/core/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/mz_focusnews/core/navigation/NavGraph.kt
@@ -1,13 +1,19 @@
 package com.example.mz_focusnews.core.navigation
 
 import androidx.compose.runtime.Composable
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
 import com.example.mz_focusnews.core.components.BottomNavItem
+import com.example.mz_focusnews.core.components.ScreenRoute
 import com.example.mz_focusnews.feature.category.CategoryScreen
 import com.example.mz_focusnews.feature.content.ContentScreen
+import com.example.mz_focusnews.feature.content.ContentViewModel
 import com.example.mz_focusnews.feature.home.HomeScreen
+import com.example.mz_focusnews.feature.home.HomeViewModel
 import com.example.mz_focusnews.feature.like.LikeNewsScreen
 import com.example.mz_focusnews.feature.mypage.MyPageScreen
 import com.example.mz_focusnews.feature.quiz.QuizIntroScreen
@@ -20,38 +26,48 @@ import com.example.mz_focusnews.feature.recent.RecentNewsScreen
 fun NavGraph(navController: NavHostController, onDrawerOpen: () -> Unit) {
     NavHost(navController = navController, startDestination = BottomNavItem.Home.route) {
         composable(BottomNavItem.Home.route) {
-            HomeScreen(navController, onDrawerOpen)
+            val viewModel: HomeViewModel = viewModel()  // 직접 ViewModel 생성
+            HomeScreen(viewModel, navController, onDrawerOpen)
         }
+
         composable(BottomNavItem.Category.route) {
             CategoryScreen(navController)
         }
+
         composable(BottomNavItem.Quiz.route) {
             QuizScreen(navController)
         }
+
         composable(BottomNavItem.MyPage.route) {
             MyPageScreen(navController)
         }
-        composable("content") {
-            ContentScreen(navController)
+
+        composable(
+            route = ScreenRoute.Content.route,
+            arguments = listOf(navArgument("newsId") { type = NavType.StringType })
+        ) { backStackEntry ->
+            val newsIdStr = backStackEntry.arguments?.getString("newsId") ?: "0"
+            val viewModel: ContentViewModel = viewModel(backStackEntry)
+            ContentScreen(viewModel, newsIdStr, navController)
         }
 
-        composable("like") {
+        composable(ScreenRoute.Like.route) {
             LikeNewsScreen(navController)
         }
 
-        composable("recent") {
+        composable(ScreenRoute.Recent.route) {
             RecentNewsScreen(navController)
         }
 
-        composable("quiz_intro") {
+        composable(ScreenRoute.QuizIntro.route) {
             QuizIntroScreen(navController)
         }
 
-        composable("quiz_play") {
+        composable(ScreenRoute.QuizPlay.route) {
             QuizPlayScreen(navController)
         }
 
-        composable("ranking") {
+        composable(ScreenRoute.Ranking.route) {
             RankingScreen()
         }
     }

--- a/app/src/main/java/com/example/mz_focusnews/core/navigation/ScreenRoute.kt
+++ b/app/src/main/java/com/example/mz_focusnews/core/navigation/ScreenRoute.kt
@@ -1,0 +1,10 @@
+package com.example.mz_focusnews.core.navigation
+
+sealed class ScreenRoute(val route: String) {
+    object Content : ScreenRoute("content/{newsId}")
+    object Like : ScreenRoute("like")
+    object Recent : ScreenRoute("recent")
+    object QuizIntro : ScreenRoute("quiz_intro")
+    object QuizPlay : ScreenRoute("quiz_play")
+    object Ranking : ScreenRoute("ranking")
+}

--- a/app/src/main/java/com/example/mz_focusnews/feature/content/ContentScreen.kt
+++ b/app/src/main/java/com/example/mz_focusnews/feature/content/ContentScreen.kt
@@ -1,6 +1,5 @@
 package com.example.mz_focusnews.feature.content
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -14,6 +13,8 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -23,16 +24,16 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
-import com.example.mz_focusnews.R
+import coil.compose.AsyncImage
 import com.example.mz_focusnews.core.components.BackBtn
 import com.example.mz_focusnews.core.components.BookmarkBtn
 import com.example.mz_focusnews.core.components.RoundedCornerBox
@@ -44,11 +45,21 @@ import com.example.mz_focusnews.core.theme.myiconpack.NonBookmark
 import com.example.mz_focusnews.core.theme.preFontFamily
 
 @Composable
-fun ContentScreen(navController: NavController) {
+fun ContentScreen(
+    viewModel: ContentViewModel,
+    newsId: String,
+    navController: NavController
+) {
+    val contentState = viewModel.contentState.collectAsState().value  // StateFlow 관찰
 
     var isBookmarked by remember { mutableStateOf(false) } // 북마크 여부
 
     val iconRes = if (isBookmarked) MyIconPack.Bookmark else MyIconPack.NonBookmark
+
+    LaunchedEffect(newsId) {
+        val id = newsId.toLongOrNull() ?: 0L
+        viewModel.fetchNewsDetail(id) // id가 변경될 때마다 새로운 데이터를 가져오도록 호출
+    }
 
     Surface(
         modifier = Modifier
@@ -88,122 +99,110 @@ fun ContentScreen(navController: NavController) {
                 )
             }
 
-            LazyColumn {
-                item {
-                    Image(
-                        painter = painterResource(R.drawable.example2),
-                        contentDescription = "exmaple image",
-                        modifier = Modifier
-                            .clip(RoundedCornerShape(12.dp))
-                            .height(210.dp),
-                        contentScale = ContentScale.Crop
-                    )
+            contentState.news?.let { detail ->
+                LazyColumn {
+                    item {
 
-                    Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(top = 15.dp),
-                        verticalArrangement = Arrangement.spacedBy(15.dp)
-                    ) {
-                        Text(
-                            text = "의대교수 사직서 제출 행렬…정부 \"5월 2천명 증원 마무리\" 쐐기",
-                            style = TextStyle(
-                                fontFamily = preFontFamily,
-                                fontWeight = FontWeight.Bold,
-                                fontSize = 20.sp
-                            )
+                        // 뉴스 썸네일
+                        AsyncImage(
+                            model = detail.imgUrl,
+                            contentDescription = "News Image",
+                            modifier = Modifier
+                                .clip(RoundedCornerShape(12.dp))
+                                .height(210.dp),
+                            contentScale = ContentScale.Crop
                         )
 
-                        RoundedCornerBox(
-                            radius = 18.dp, bgColor = Blue_900
-                        ) {
-                            Text(
-                                modifier = Modifier.fillMaxWidth(),
-                                text = "정부와 의료계 대화가 둔화되면서 의대 교수들이 사직서를 제출하고 있다.",
-                                style = TextStyle(
-                                    fontFamily = preFontFamily,
-                                    fontWeight = FontWeight.SemiBold,
-                                    fontSize = 14.sp
-                                ),
-                                color = Color.White
-                            )
-                        }
-
-                        RoundedCornerBox(
-                            radius = 18.dp, bgColor = Blue_900
-                        ) {
-                            Text(
-                                modifier = Modifier.fillMaxWidth(),
-                                text = "정부와 의료계 대화가 둔화되면서 의대 교수들이 사직서를 제출하고 있다.",
-                                style = TextStyle(
-                                    fontFamily = preFontFamily,
-                                    fontWeight = FontWeight.SemiBold,
-                                    fontSize = 14.sp
-                                ),
-                                color = Color.White
-                            )
-                        }
-
-                        RoundedCornerBox(
-                            radius = 18.dp, bgColor = Blue_900
-                        ) {
-                            Text(
-                                modifier = Modifier.fillMaxWidth(),
-                                text = "정부와 의료계 대화가 둔화되면서 의대 교수들이 사직서를 제출하고 있다.",
-                                style = TextStyle(
-                                    fontFamily = preFontFamily,
-                                    fontWeight = FontWeight.SemiBold,
-                                    fontSize = 14.sp
-                                ),
-                                color = Color.White
-                            )
-                        }
-                    }
-
-                    Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(top = 25.dp),
-                        verticalArrangement = Arrangement.spacedBy(10.dp)
-                    ) {
-                        Text(
-                            text = "의대교수 사직서에 대해 더 알고싶다면?",
-                            style = TextStyle(
-                                fontFamily = preFontFamily,
-                                fontWeight = FontWeight.Medium,
-                                fontSize = 16.sp
-                            ),
+                        // 뉴스 내용
+                        Column(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .padding(start = 10.dp)
-                        )
-
-                        RoundedCornerBox(
-                            radius = 18.dp, bgColor = Color.White
+                                .padding(top = 15.dp),
+                            verticalArrangement = Arrangement.spacedBy(15.dp)
                         ) {
+
+                            // 뉴스 제목
                             Text(
-                                modifier = Modifier.fillMaxWidth(),
-                                text = "정부와 의료계 대화가 둔화되면서 의대 교수들이 사직서를 제출하고 있다.",
+                                text = detail.title,
                                 style = TextStyle(
                                     fontFamily = preFontFamily,
-                                    fontWeight = FontWeight.SemiBold,
-                                    fontSize = 14.sp
+                                    fontWeight = FontWeight.Bold,
+                                    fontSize = 20.sp
                                 )
                             )
-                        }
 
-                        RoundedCornerBox(
-                            radius = 18.dp, bgColor = Color.White
-                        ) {
-                            Text(
-                                modifier = Modifier.fillMaxWidth(),
-                                text = "정부와 의료계 대화가 둔화되면서 의대 교수들이 사직서를 제출하고 있다.",
-                                style = TextStyle(
-                                    fontFamily = preFontFamily,
-                                    fontWeight = FontWeight.SemiBold,
-                                    fontSize = 14.sp
+                            // 3줄 요약
+                            // summary는 총 세 문장으로만 이루어져있다 (온점도 단 세개만 존재)
+                            val sentences = detail.summary.split(".").map { it.trim() }
+                                .filter { it.isNotEmpty() }
+                            Column(
+                                verticalArrangement = Arrangement.spacedBy(15.dp)
+                            ) {
+                                sentences.forEach { sentence ->
+                                    RoundedCornerBox(
+                                        radius = 18.dp,
+                                        bgColor = Blue_900
+                                    ) {
+                                        Text(
+                                            modifier = Modifier.fillMaxWidth(),
+                                            text = sentence,
+                                            style = TextStyle(
+                                                fontFamily = preFontFamily,
+                                                fontWeight = FontWeight.SemiBold,
+                                                fontSize = 14.sp
+                                            ),
+                                            color = Color.White
+                                        )
+                                    }
+                                }
+                            }
+
+                            Column(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(top = 25.dp),
+                                verticalArrangement = Arrangement.spacedBy(10.dp)
+                            ) {
+                                Text(
+                                    text = "의대교수 사직서에 대해 더 알고싶다면?",
+                                    style = TextStyle(
+                                        fontFamily = preFontFamily,
+                                        fontWeight = FontWeight.Medium,
+                                        fontSize = 16.sp
+                                    ),
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(start = 10.dp)
                                 )
-                            )
+
+                                RoundedCornerBox(
+                                    radius = 18.dp, bgColor = Color.White
+                                ) {
+                                    Text(
+                                        modifier = Modifier.fillMaxWidth(),
+                                        text = "정부와 의료계 대화가 둔화되면서 의대 교수들이 사직서를 제출하고 있다.",
+                                        style = TextStyle(
+                                            fontFamily = preFontFamily,
+                                            fontWeight = FontWeight.SemiBold,
+                                            fontSize = 14.sp
+                                        )
+                                    )
+                                }
+
+                                RoundedCornerBox(
+                                    radius = 18.dp, bgColor = Color.White
+                                ) {
+                                    Text(
+                                        modifier = Modifier.fillMaxWidth(),
+                                        text = "정부와 의료계 대화가 둔화되면서 의대 교수들이 사직서를 제출하고 있다.",
+                                        style = TextStyle(
+                                            fontFamily = preFontFamily,
+                                            fontWeight = FontWeight.SemiBold,
+                                            fontSize = 14.sp
+                                        )
+                                    )
+                                }
+                            }
                         }
                     }
                 }
@@ -215,5 +214,5 @@ fun ContentScreen(navController: NavController) {
 @Preview
 @Composable
 fun ContentPreview() {
-    ContentScreen(rememberNavController())
+    ContentScreen(viewModel(), "0", rememberNavController())
 }

--- a/app/src/main/java/com/example/mz_focusnews/feature/content/ContentScreen.kt
+++ b/app/src/main/java/com/example/mz_focusnews/feature/content/ContentScreen.kt
@@ -1,6 +1,10 @@
 package com.example.mz_focusnews.feature.content
 
+import android.content.Context
+import android.net.Uri
+import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -24,6 +28,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -53,8 +58,9 @@ fun ContentScreen(
     val contentState = viewModel.contentState.collectAsState().value  // StateFlow 관찰
 
     var isBookmarked by remember { mutableStateOf(false) } // 북마크 여부
-
     val iconRes = if (isBookmarked) MyIconPack.Bookmark else MyIconPack.NonBookmark
+
+    val context = LocalContext.current
 
     LaunchedEffect(newsId) {
         val id = newsId.toLongOrNull() ?: 0L
@@ -109,7 +115,10 @@ fun ContentScreen(
                             contentDescription = "News Image",
                             modifier = Modifier
                                 .clip(RoundedCornerShape(12.dp))
-                                .height(210.dp),
+                                .height(210.dp)
+                                .clickable {
+                                    openWebPage(context, detail.link)
+                                },
                             contentScale = ContentScale.Crop
                         )
 
@@ -209,6 +218,16 @@ fun ContentScreen(
             }
         }
     }
+}
+
+// 웹으로 이동하는 함수
+private fun openWebPage(context: Context, url: String) {
+    if (url.isEmpty()) return
+
+    val customTabsIntent = CustomTabsIntent.Builder()
+        .build()
+
+    customTabsIntent.launchUrl(context, Uri.parse(url))
 }
 
 @Preview

--- a/app/src/main/java/com/example/mz_focusnews/feature/content/ContentViewModel.kt
+++ b/app/src/main/java/com/example/mz_focusnews/feature/content/ContentViewModel.kt
@@ -1,0 +1,49 @@
+package com.example.mz_focusnews.feature.content
+
+import android.util.Log
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.mz_focusnews.core.api.model.NewsDetail
+import com.example.mz_focusnews.core.api.service.ApiService
+import com.example.mz_focusnews.core.api.service.RetrofitClient
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+class ContentViewModel(
+    savedStateHandle: SavedStateHandle // NavController로 넘긴 인자를 받기 위함
+) : ViewModel() {
+    private val service: ApiService = RetrofitClient.getInstance().create(ApiService::class.java)
+
+    private val _contentState = MutableStateFlow(ContentState())
+    val contentState: StateFlow<ContentState> = _contentState
+
+    val newsId = savedStateHandle.get<String>("newsId")?.toLongOrNull() ?: 0L
+
+    init {
+        fetchNewsDetail(newsId)
+        Log.d("Retrofit", "init news id = $newsId")
+    }
+
+    fun fetchNewsDetail(newsId: Long) {
+        _contentState.value = ContentState(isLoading = true)  // 로딩 시작
+
+        Log.d("Retrofit", "fetch news id = $newsId")
+        viewModelScope.launch {
+            try {
+                val response = service.getNewsDetail(newsId)
+                _contentState.value = ContentState(news = response.data, isLoading = false)
+                Log.d("Retrofit", _contentState.toString())
+            } catch (e: Exception) {
+                _contentState.value = ContentState(isLoading = false)
+                Log.e("Retrofit", "Error")
+            }
+        }
+    }
+}
+
+data class ContentState(
+    val news: NewsDetail? = null,
+    val isLoading: Boolean = false
+)

--- a/app/src/main/java/com/example/mz_focusnews/feature/home/BreakingSection.kt
+++ b/app/src/main/java/com/example/mz_focusnews/feature/home/BreakingSection.kt
@@ -26,36 +26,47 @@ import com.example.mz_focusnews.core.theme.Bg_Blue
 import com.example.mz_focusnews.core.theme.preFontFamily
 
 @Composable
-fun BreakingSection(navigateToContent: () -> Unit) {
+fun BreakingSection(breakingState: BreakingState, navigateToContent: (id: Long) -> Unit) {
+    if (breakingState.breakingNews == null) {
+        return
+    }
+
     Surface(
         modifier = Modifier
             .fillMaxWidth()
             .padding(top = 2.dp)
     ) {
-        Box(
-            modifier = Modifier.fillMaxWidth().background(Bg_Blue)
-        ) {
-            Row(
+        breakingState.breakingNews.breakingNewsRecent.let { news ->
+
+            Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .background(Color.White, RoundedCornerShape(12.dp))
-                    .padding(horizontal = 14.dp, vertical = 13.dp),
-                verticalAlignment = Alignment.CenterVertically
+                    .background(Bg_Blue)
             ) {
-                Image(
-                    painter = painterResource(R.drawable.icon_breaking),
-                    contentDescription = "breaking news icon",
-                    modifier = Modifier.size(25.dp)
-                )
-                Text(
-                    modifier = Modifier.padding(start = 12.dp).clickable { navigateToContent() },
-                    text = "산림청 \"경북 영덕 산불 주불 진화\" 평균 진화율 94% 넘어",
-                    style = TextStyle(
-                        fontFamily = preFontFamily,
-                        fontWeight = FontWeight.SemiBold,
-                        fontSize = 12.5.sp
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(Color.White, RoundedCornerShape(12.dp))
+                        .padding(horizontal = 14.dp, vertical = 13.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Image(
+                        painter = painterResource(R.drawable.icon_breaking),
+                        contentDescription = "breaking news icon",
+                        modifier = Modifier.size(25.dp)
                     )
-                )
+                    Text(
+                        modifier = Modifier
+                            .padding(start = 12.dp)
+                            .clickable { navigateToContent(news.id) },
+                        text = news.title,
+                        style = TextStyle(
+                            fontFamily = preFontFamily,
+                            fontWeight = FontWeight.SemiBold,
+                            fontSize = 12.5.sp
+                        )
+                    )
+                }
             }
         }
     }
@@ -64,5 +75,5 @@ fun BreakingSection(navigateToContent: () -> Unit) {
 @Preview
 @Composable
 fun BreakingPreview() {
-    BreakingSection({ })
+    BreakingSection(BreakingState(), { })
 }

--- a/app/src/main/java/com/example/mz_focusnews/feature/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/mz_focusnews/feature/home/HomeScreen.kt
@@ -1,5 +1,6 @@
 package com.example.mz_focusnews.feature.home
 
+import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -10,16 +11,24 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.example.mz_focusnews.core.theme.Bg_Blue
 import com.example.mz_focusnews.core.theme.Gray_200
 
 @Composable
-fun HomeScreen(navController: NavController, onDrawerOpen: () -> Unit) {
+fun HomeScreen(
+    viewModel: HomeViewModel,
+    navController: NavController,
+    onDrawerOpen: () -> Unit
+) {
+    val newsState = viewModel.newsState.collectAsState().value  // StateFlow 관찰
+
     Surface(
         modifier = Modifier
             .fillMaxSize()
@@ -35,10 +44,14 @@ fun HomeScreen(navController: NavController, onDrawerOpen: () -> Unit) {
             // Breaking Drawer Open Button
             UserGuideSection(onDrawerOpen)
 
-            BreakingSection({ navigateToContent(navController) })
+            BreakingSection({
+//                navigateToContent(navController)
+            })
 
-            NewsSection({ navigateToContent(navController) })
+            NewsSection(newsState) { newsId ->
+                navigateToContent(newsId, navController)
 
+            }
             Spacer(
                 modifier = Modifier
                     .height(2.dp)
@@ -46,17 +59,20 @@ fun HomeScreen(navController: NavController, onDrawerOpen: () -> Unit) {
                     .background(Gray_200)
             )
 
-            RecommendedNewsSection({ navigateToContent(navController) })
+            RecommendedNewsSection({
+//                navigateToContent(navController)
+            })
         }
     }
 }
 
-fun navigateToContent(navController: NavController) {
-    navController.navigate("content")
+private fun navigateToContent(newsId: Long, navController: NavController) {
+    navController.navigate("content/$newsId")
+    Log.d("Retrofit", "clicked news id = $newsId")
 }
 
 @Preview
 @Composable
 fun HomePreview() {
-    HomeScreen(rememberNavController(), {})
+    HomeScreen(viewModel(), rememberNavController(), {})
 }

--- a/app/src/main/java/com/example/mz_focusnews/feature/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/mz_focusnews/feature/home/HomeScreen.kt
@@ -28,6 +28,7 @@ fun HomeScreen(
     onDrawerOpen: () -> Unit
 ) {
     val newsState = viewModel.newsState.collectAsState().value  // StateFlow 관찰
+    val breakingState = viewModel.breakingState.collectAsState().value
 
     Surface(
         modifier = Modifier
@@ -44,13 +45,12 @@ fun HomeScreen(
             // Breaking Drawer Open Button
             UserGuideSection(onDrawerOpen)
 
-            BreakingSection({
-//                navigateToContent(navController)
-            })
+            BreakingSection(breakingState){ newsId ->
+                navigateToContent(newsId, navController)
+            }
 
             NewsSection(newsState) { newsId ->
                 navigateToContent(newsId, navController)
-
             }
             Spacer(
                 modifier = Modifier

--- a/app/src/main/java/com/example/mz_focusnews/feature/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/mz_focusnews/feature/home/HomeViewModel.kt
@@ -1,0 +1,41 @@
+package com.example.mz_focusnews.feature.home
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.mz_focusnews.core.api.model.NewsGroup
+import com.example.mz_focusnews.core.api.service.ApiService
+import com.example.mz_focusnews.core.api.service.RetrofitClient
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+class HomeViewModel : ViewModel() {
+    private val service: ApiService = RetrofitClient.getInstance().create(ApiService::class.java)
+
+    private val _newsState = MutableStateFlow(NewsState())
+    val newsState: StateFlow<NewsState> = _newsState
+
+    init {
+        fetchNews()
+    }
+
+    fun fetchNews() {
+        _newsState.value = NewsState(isLoading = true)  // 로딩 시작
+        viewModelScope.launch {
+            try {
+                val response = service.getMainNewsData()
+                _newsState.value = NewsState(newsGroup = response.data, isLoading = false)
+                Log.d("Retrofit", _newsState.toString())
+            } catch (e: Exception) {
+                _newsState.value = NewsState(isLoading = false)
+                Log.e("Retrofit", "Error")
+            }
+        }
+    }
+}
+
+data class NewsState(
+    val newsGroup: NewsGroup? = null,
+    val isLoading: Boolean = false  // 로딩 상태
+)

--- a/app/src/main/java/com/example/mz_focusnews/feature/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/mz_focusnews/feature/home/HomeViewModel.kt
@@ -3,6 +3,7 @@ package com.example.mz_focusnews.feature.home
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.mz_focusnews.core.api.model.BreakingNews
 import com.example.mz_focusnews.core.api.model.NewsGroup
 import com.example.mz_focusnews.core.api.service.ApiService
 import com.example.mz_focusnews.core.api.service.RetrofitClient
@@ -16,11 +17,15 @@ class HomeViewModel : ViewModel() {
     private val _newsState = MutableStateFlow(NewsState())
     val newsState: StateFlow<NewsState> = _newsState
 
+    private val _breakingState = MutableStateFlow(BreakingState())
+    val breakingState: StateFlow<BreakingState> = _breakingState
+
     init {
-        fetchNews()
+        fetchMainNews()
+        fetchBreakingNews()
     }
 
-    fun fetchNews() {
+    fun fetchMainNews() {
         _newsState.value = NewsState(isLoading = true)  // 로딩 시작
         viewModelScope.launch {
             try {
@@ -33,9 +38,30 @@ class HomeViewModel : ViewModel() {
             }
         }
     }
+
+    fun fetchBreakingNews() {
+        _breakingState.value = BreakingState(isLoading = true)
+        viewModelScope.launch {
+            try {
+                val response = service.getBreakingNews()
+                _breakingState.value =
+                    BreakingState(breakingNews = response.data, isLoading = false)
+                Log.d("Retrofit", _breakingState.toString())
+            } catch (e: Exception) {
+                _breakingState.value = BreakingState(isLoading = false)
+                Log.e("Retrofit", "Error")
+            }
+        }
+
+    }
 }
 
 data class NewsState(
     val newsGroup: NewsGroup? = null,
-    val isLoading: Boolean = false  // 로딩 상태
+    val isLoading: Boolean = false
+)
+
+data class BreakingState(
+    val breakingNews: BreakingNews? = null,
+    val isLoading: Boolean = false
 )

--- a/app/src/main/java/com/example/mz_focusnews/feature/home/NewsSection.kt
+++ b/app/src/main/java/com/example/mz_focusnews/feature/home/NewsSection.kt
@@ -1,6 +1,5 @@
 package com.example.mz_focusnews.feature.home
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -22,32 +21,37 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.example.mz_focusnews.R
+import coil.compose.AsyncImage
+import com.example.mz_focusnews.core.api.model.News
 import com.example.mz_focusnews.core.theme.Gray_600
 import com.example.mz_focusnews.core.theme.Today_Blue
 import com.example.mz_focusnews.core.theme.preFontFamily
 
 @Composable
-fun NewsSection(navigateToContent: () -> Unit) {
+fun NewsSection(newsState: NewsState, navigateToContent: (id: Long) -> Unit) {
     val pagerState = rememberPagerState { 3 } // 총 페이지 수 설정
 
     var text = ""
+    var news: News? = null
+
+    // 데이터 로딩 중이거나 null인 경우 처리
+    if (newsState.newsGroup == null) {
+        // 로딩 인디케이터 처리 고려중
+        return
+    }
 
     Surface(
         modifier = Modifier
             .fillMaxWidth()
             .padding(top = 2.dp, bottom = 8.dp)
     ) {
-        /**
-         * TODO: 페이지 별로 다른 내용 렌더링되게 수정
-         */
         HorizontalPager(
             modifier = Modifier.fillMaxWidth(),
             state = pagerState
@@ -58,92 +62,122 @@ fun NewsSection(navigateToContent: () -> Unit) {
                 2 -> text = "이달의 뉴스"
             }
 
-            Card(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clip(RoundedCornerShape(12.dp))
-                    .background(Today_Blue)
-                    .height(185.dp)
-                    .padding(start = 18.dp, top = 18.dp, end = 18.dp),
+            when (page) {
+                0 -> news = newsState.newsGroup.day
+                1 -> news = newsState.newsGroup.week
+                2 -> news = newsState.newsGroup.month
+            }
 
-                ) {
-                Text(
-                    text = text,
-                    style = TextStyle(
-                        fontFamily = preFontFamily,
-                        fontWeight = FontWeight.Bold,
-                        fontSize = 15.sp
-                    ),
+            news?.let { news ->
+                Card(
                     modifier = Modifier
                         .fillMaxWidth()
+                        .clip(RoundedCornerShape(12.dp))
                         .background(Today_Blue)
-                        .padding(start = 2.dp, bottom = 12.dp)
-                )
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .background(Today_Blue)
-                ) {
-                    Row {
-                        Image(
-                            painter = painterResource(R.drawable.example),
-                            contentDescription = "exmaple image",
-                            modifier = Modifier
-                                .width(158.dp)
-                                .height(114.dp)
-                                .background(Color.White),
-                        )
+                        .height(185.dp)
+                        .padding(start = 18.dp, top = 18.dp, end = 18.dp),
 
-                        /**
-                         * news description
-                         */
-                        Column(
-                            modifier = Modifier
-                                .fillMaxHeight()
-                                .padding(start = 12.dp, top = 4.dp)
-                        ) {
-                            Text(
-                                text = "안동서 누각·재사 전소 추가 확인, 산불 피해 국가유산 27건",
-                                style = TextStyle(
-                                    fontFamily = preFontFamily,
-                                    fontWeight = FontWeight.Bold,
-                                    fontSize = 15.sp
-                                ),
-                                modifier = Modifier.clickable { navigateToContent() }
-                            )
-                            Text(
-                                text = "산불 사태로 인한 국가유산 피해 사례가 27건으로 ...",
-                                style = TextStyle(
-                                    fontFamily = preFontFamily,
-                                    fontWeight = FontWeight.SemiBold,
-                                    color = Gray_600,
-                                    fontSize = 13.sp
-                                ),
-                                modifier = Modifier.padding(top = 6.dp)
-                            )
-                            Text(
-                                text = "2025.03.28",
-                                style = TextStyle(
-                                    fontFamily = preFontFamily,
-                                    fontWeight = FontWeight.Medium,
-                                    fontSize = 10.sp
-                                ),
+                    ) {
+                    Text(
+                        text = text,
+                        style = TextStyle(
+                            fontFamily = preFontFamily,
+                            fontWeight = FontWeight.Bold,
+                            fontSize = 15.sp
+                        ),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(Today_Blue)
+                            .padding(start = 2.dp, bottom = 12.dp)
+                    )
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(Today_Blue)
+                    ) {
+                        Row {
+                            // 뉴스 썸네일
+                            AsyncImage(
+                                model = news.imgUrl,
+                                contentDescription = "News Image",
                                 modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(top = 12.dp),
-                                textAlign = TextAlign.End
+                                    .width(158.dp)
+                                    .height(114.dp)
+                                    .background(Color.White),
+                                contentScale = ContentScale.Crop
                             )
+
+                            /**
+                             * news description
+                             */
+                            Column(
+                                modifier = Modifier
+                                    .fillMaxHeight()
+                                    .padding(start = 12.dp, top = 4.dp)
+                            ) {
+                                // 뉴스 제목
+                                Text(
+                                    text = news.title,
+                                    style = TextStyle(
+                                        fontFamily = preFontFamily,
+                                        fontWeight = FontWeight.Bold,
+                                        fontSize = 15.sp
+                                    ),
+                                    modifier = Modifier.clickable { navigateToContent(news.id) }
+                                )
+
+
+                                // 뉴스 내용
+                                Text(
+                                    text = contentSplit(news.content),
+                                    style = TextStyle(
+                                        fontFamily = preFontFamily,
+                                        fontWeight = FontWeight.SemiBold,
+                                        color = Gray_600,
+                                        fontSize = 13.sp
+                                    ),
+                                    modifier = Modifier.padding(top = 6.dp)
+                                )
+
+                                // 뉴스 발행일
+                                Text(
+                                    text = news.date,
+                                    style = TextStyle(
+                                        fontFamily = preFontFamily,
+                                        fontWeight = FontWeight.Medium,
+                                        fontSize = 10.sp
+                                    ),
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(top = 12.dp),
+                                    textAlign = TextAlign.End
+                                )
+                            }
                         }
                     }
                 }
             }
-
         }
     }
 }
 
+// 뉴스 content 스트링 자르는 함수
+private fun contentSplit(content: String): String {
+    val max = 25
+    if (content.length <= max) return content
+
+    val index = content.indexOf(' ', startIndex = max)
+
+    return if (index != -1) {
+        content.substring(0, index) + "..."
+    } else {
+        content.substring(0, max) + "..."
+    }
+}
+
+
 @Preview
 @Composable
 fun NewsPreview() {
-    NewsSection({ })
+    NewsSection(NewsState(), { })
 }

--- a/app/src/main/java/com/example/mz_focusnews/main/MainScreen.kt
+++ b/app/src/main/java/com/example/mz_focusnews/main/MainScreen.kt
@@ -10,23 +10,30 @@ import androidx.compose.material.rememberDrawerState
 import androidx.compose.material3.ModalDrawerSheet
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.rememberNavController
 import com.example.mz_focusnews.core.components.BottomNavBar
 import com.example.mz_focusnews.core.components.DrawerScreen
 import com.example.mz_focusnews.core.navigation.NavGraph
 import com.example.mz_focusnews.core.theme.Bg_Blue
+import com.example.mz_focusnews.feature.home.HomeViewModel
 import kotlinx.coroutines.launch
 
 @Composable
 fun MainScreen() {
     val navController = rememberNavController()
-
     val coroutineScope = rememberCoroutineScope()
     val drawerState = rememberDrawerState(DrawerValue.Closed)
+
+    val viewModel: HomeViewModel = viewModel()
+    val breakingState = viewModel.breakingState.collectAsState().value
+
+    val breakingList = breakingState.breakingNews?.breakingNews
 
     ModalDrawer( // TODO: drawer 열리는 방향 RtL로 변경!
         modifier = Modifier
@@ -37,7 +44,16 @@ fun MainScreen() {
         drawerBackgroundColor = Color.White,
         drawerContent = {
             ModalDrawerSheet {
-                DrawerScreen()
+                if (breakingList != null) {
+                    DrawerScreen(
+                        onDrawerClosed = {
+                            coroutineScope.launch {
+                                drawerState.close()
+                            }
+                        },
+                        breakingNews = breakingList,
+                        navigateToContent = { newsId -> navController.navigate("content/$newsId") })
+                }
             }
         },
         gesturesEnabled = drawerState.isOpen
@@ -55,11 +71,15 @@ fun MainScreen() {
                     .fillMaxSize()
                     .background(Bg_Blue)
             ) {
-                NavGraph(navController = navController, onDrawerOpen = {
-                    coroutineScope.launch {
-                        drawerState.open()
+                NavGraph(
+                    navController = navController,
+                    homeViewModel = viewModel,
+                    onDrawerOpen = {
+                        coroutineScope.launch {
+                            drawerState.open()
+                        }
                     }
-                })
+                )
             }
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 agp = "8.8.0"
+coilCompose = "2.4.0"
 junit = "4.13.2"
 junitVersion = "1.1.5"
 espressoCore = "3.5.1"
@@ -20,6 +21,7 @@ androidx-navigation-compose = { module = "androidx.navigation:navigation-compose
 androidx-ui = { module = "androidx.compose.ui:ui" }
 androidx-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 androidx-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
+coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coilCompose" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #13 

## Key Changes 🔑
- 오늘/이주/이달 뉴스 목록 조회 API 연동
- 뉴스 클릭 시 상세 내용(newsId 기반) 조회 및 화면 반영
- 속보(Breaking News) API 연동 및 Drawer에 속보 목록 표시
- 속보 클릭 시 상세 페이지로 이동 처리
- Chrome Custom Tabs를 이용해 뉴스 원본 링크 열기 기능 추가