### PR TITLE
feature: 사용자 키워드 등록 및 삭제 기능 구현

### DIFF
--- a/app/src/main/java/com/example/mz_focusnews/core/api/model/KeywordRequest.kt
+++ b/app/src/main/java/com/example/mz_focusnews/core/api/model/KeywordRequest.kt
@@ -1,0 +1,12 @@
+package com.example.mz_focusnews.core.api.model
+
+data class SetKeywordRequest(
+    val id: Long, // 사용자 아이디
+    val previousKeyword: String,
+    val newKeyword: String
+)
+
+data class DelKeywordRequest(
+    val userId: Long,
+    val keyword: String
+)

--- a/app/src/main/java/com/example/mz_focusnews/core/api/service/ApiService.kt
+++ b/app/src/main/java/com/example/mz_focusnews/core/api/service/ApiService.kt
@@ -2,6 +2,8 @@ package com.example.mz_focusnews.core.api.service
 
 import com.example.mz_focusnews.core.api.ApiResponse
 import com.example.mz_focusnews.core.api.model.BreakingNews
+import com.example.mz_focusnews.core.api.model.DelKeywordRequest
+import com.example.mz_focusnews.core.api.model.SetKeywordRequest
 import com.example.mz_focusnews.core.api.model.NewsList
 import com.example.mz_focusnews.core.api.model.MainInfo
 import com.example.mz_focusnews.core.api.model.MyPageInfo
@@ -9,7 +11,11 @@ import com.example.mz_focusnews.core.api.model.NewsDetail
 import com.example.mz_focusnews.core.api.model.NewsGroup
 import com.example.mz_focusnews.core.api.model.NewsResponse
 import com.example.mz_focusnews.core.api.model.RelatedNewsList
+import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
+import retrofit2.http.HTTP
+import retrofit2.http.POST
 import retrofit2.http.Query
 
 interface ApiService {
@@ -51,5 +57,15 @@ interface ApiService {
         @Query("userId") userId: Long,
         @Query("type") sort: String = "recent"
     ): ApiResponse<NewsList>
+
+    @POST("/user/v1/keyword")
+    suspend fun setUserKeyword(
+        @Body req: SetKeywordRequest
+    ): ApiResponse<Unit>
+
+    @HTTP(method = "DELETE", path = "/user/v1/keyword", hasBody = true)
+    suspend fun deleteUserKeyword(
+        @Body req: DelKeywordRequest
+    ): ApiResponse<Unit>
 }
 

--- a/app/src/main/java/com/example/mz_focusnews/core/components/StatusCard.kt
+++ b/app/src/main/java/com/example/mz_focusnews/core/components/StatusCard.kt
@@ -26,12 +26,18 @@ import androidx.compose.ui.unit.sp
 import com.example.mz_focusnews.core.theme.preFontFamily
 
 @Composable
-fun StatusCard(bgColor: Color = Color.Transparent, radius: Dp = 12.dp, imgRes: Int, msg: String) {
+fun StatusCard(
+    bgColor: Color = Color.Transparent,
+    radius: Dp = 12.dp,
+    showImage: Boolean = true,
+    imgRes: Int,
+    msg: String
+) {
     Card(
         modifier = Modifier
             .fillMaxSize()
             .clip(RoundedCornerShape(radius)),
-        colors= CardDefaults.cardColors(
+        colors = CardDefaults.cardColors(
             containerColor = bgColor
         ),
     ) {
@@ -43,11 +49,15 @@ fun StatusCard(bgColor: Color = Color.Transparent, radius: Dp = 12.dp, imgRes: I
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center
         ) {
-            Image(
-                modifier = Modifier.size(60.dp),
-                painter = painterResource(imgRes),
-                contentDescription = "Error Kitty Image",
-            )
+            if (showImage) {
+                Image(
+                    modifier = Modifier
+                        .size(60.dp)
+                        .padding(bottom = 12.dp),
+                    painter = painterResource(imgRes),
+                    contentDescription = "Error Kitty Image",
+                )
+            }
 
             Text(
                 text = msg,
@@ -57,8 +67,7 @@ fun StatusCard(bgColor: Color = Color.Transparent, radius: Dp = 12.dp, imgRes: I
                     fontWeight = FontWeight.Medium,
                     color = Color.Black,
                     fontSize = 14.sp
-                ),
-                modifier = Modifier.padding(top = 12.dp)
+                )
             )
         }
     }

--- a/app/src/main/java/com/example/mz_focusnews/feature/content/ContentScreen.kt
+++ b/app/src/main/java/com/example/mz_focusnews/feature/content/ContentScreen.kt
@@ -94,7 +94,7 @@ fun ContentScreen(
                 BackBtn(navController, modifier = Modifier.align(Alignment.CenterStart))
 
                 Text(
-                    text = "news",
+                    text = "",
                     style = TextStyle(
                         fontFamily = preFontFamily,
                         fontWeight = FontWeight.Medium,
@@ -236,15 +236,15 @@ fun ContentScreen(
                             // 정상 응답 처리
                             else -> {
                                 Text(
-                                    text = "의대교수 사직서에 대해 더 알고싶다면?",
+                                    text = "지금 보고 있는 뉴스가 마음에 들었다면?",
                                     style = TextStyle(
                                         fontFamily = preFontFamily,
                                         fontWeight = FontWeight.Medium,
-                                        fontSize = 16.sp
+                                        fontSize = 15.sp
                                     ),
                                     modifier = Modifier
                                         .fillMaxWidth()
-                                        .padding(start = 10.dp)
+                                        .padding(start = 10.dp, top = 5.dp)
                                 )
 
                                 relatedState.relatedNewsList.relatedNewsResList.forEach { news ->

--- a/app/src/main/java/com/example/mz_focusnews/feature/home/UserGuideSection.kt
+++ b/app/src/main/java/com/example/mz_focusnews/feature/home/UserGuideSection.kt
@@ -4,8 +4,10 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -27,7 +29,6 @@ import com.example.mz_focusnews.R
 import com.example.mz_focusnews.core.components.StatusCard
 import com.example.mz_focusnews.core.theme.Bg_Blue
 import com.example.mz_focusnews.core.theme.MyIconPack
-import com.example.mz_focusnews.core.theme.Today_Blue
 import com.example.mz_focusnews.core.theme.myiconpack.Bell
 import com.example.mz_focusnews.core.theme.preFontFamily
 
@@ -56,22 +57,24 @@ fun UserGuideSection(mainInfoState: MainInfoState, onDrawerOpen: () -> Unit) {
             modifier = Modifier
                 .background(Bg_Blue)
                 .fillMaxWidth()
+                .height(IntrinsicSize.Min)
+                .padding(top = 20.dp)
         ) {
             Row {
                 when {
                     mainInfoState.isLoading -> {
                         StatusCard(
-                            bgColor = Today_Blue,
+                            showImage = false,
                             imgRes = R.drawable.img_loading_kitty,
-                            msg = "사용자 정보를 가져오는 중이에요!"
+                            msg = "사용자 정보를 가져오는 중이에요!",
                         )
                     }
 
                     mainInfoState.isError -> {
                         StatusCard(
-                            bgColor = Today_Blue,
+                            showImage = false,
                             imgRes = R.drawable.img_network_kitty,
-                            msg = "네트워크 오류가 발생했어요"
+                            msg = "네트워크 오류가 발생했어요",
                         )
                     }
 
@@ -80,7 +83,7 @@ fun UserGuideSection(mainInfoState: MainInfoState, onDrawerOpen: () -> Unit) {
                             Text(
                                 text = guideText,
                                 modifier = Modifier
-                                    .padding(top = 20.dp, bottom = 12.dp)
+                                    .padding(bottom = 12.dp)
                                     .background(Color.Transparent),
                                 style = TextStyle(
                                     fontFamily = preFontFamily,

--- a/app/src/main/java/com/example/mz_focusnews/feature/home/UserGuideSection.kt
+++ b/app/src/main/java/com/example/mz_focusnews/feature/home/UserGuideSection.kt
@@ -44,8 +44,7 @@ fun UserGuideSection(mainInfoState: MainInfoState, onDrawerOpen: () -> Unit) {
 
     val weatherIcon = when (mainInfoState.info?.weather) {
         "clear" -> R.drawable.icon_clear
-        "few clouds" -> R.drawable.icon_few_clouds
-        "scattered clouds" -> R.drawable.icon_scattered_clouds
+        "clouds" -> R.drawable.icon_scattered_clouds
         "rain" -> R.drawable.icon_rain
         "snow" -> R.drawable.icon_snow
         "thunderstorm" -> R.drawable.icon_thunderstorm

--- a/app/src/main/java/com/example/mz_focusnews/feature/mypage/AddKeywordDialog.kt
+++ b/app/src/main/java/com/example/mz_focusnews/feature/mypage/AddKeywordDialog.kt
@@ -46,10 +46,10 @@ import com.example.mz_focusnews.core.theme.preFontFamily
 @Composable
 fun AddKeywordDialog(
     onDismiss: () -> Unit,
-    onKeywordAdded: (String) -> Unit
+    onKeywordAdded: (String, String) -> Unit
 ) {
 
-    var text by remember { mutableStateOf("") }
+    var input by remember { mutableStateOf("") }
 
     Dialog(
         onDismissRequest = { onDismiss() },
@@ -102,8 +102,8 @@ fun AddKeywordDialog(
                 )
 
                 TextField(
-                    value = text,
-                    onValueChange = { text = it },
+                    value = input,
+                    onValueChange = { input = it },
                     maxLines = 1,
                     textStyle = TextStyle( // 입력된 텍스트 스타일 지정
                         fontFamily = preFontFamily,
@@ -162,7 +162,7 @@ fun AddKeywordDialog(
 
                     TextButton(
                         onClick = {
-                            onKeywordAdded(text)
+                            onKeywordAdded("", input)
                             onDismiss()
                         },
                         modifier = Modifier
@@ -197,6 +197,6 @@ fun DialogPreview() {
             .fillMaxSize()
             .background(Color.Black)
     ) {
-        AddKeywordDialog({ }, { })
+//        AddKeywordDialog({ }, { })
     }
 }

--- a/app/src/main/java/com/example/mz_focusnews/feature/mypage/KeywordSetSection.kt
+++ b/app/src/main/java/com/example/mz_focusnews/feature/mypage/KeywordSetSection.kt
@@ -2,6 +2,7 @@
 
 package com.example.mz_focusnews.feature.mypage
 
+import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -37,13 +38,11 @@ import com.example.mz_focusnews.core.theme.Yellow
 import com.example.mz_focusnews.core.theme.preFontFamily
 import com.example.mz_focusnews.core.util.keywordSplit
 
-const val MAX = 3
-
 @Composable
-fun KeywordSetSection(myPageState: MyPageState, onAddBtnClick: () -> Unit) {
-    val keywordList = myPageState.mypageInfo?.let { keywordSplit(it.keyword) }
+fun KeywordSetSection(keyword: String, onCloseBtnClick:(keyword: String) -> Unit, onAddBtnClick: () -> Unit) {
 
-    val btnCounter = when (keywordList?.size) {
+    val keywordList = keywordSplit(keyword)
+    val btnCounter = when (keywordList.size) {
         0, 2 -> 1
         1 -> 2
         else -> 0
@@ -78,7 +77,7 @@ fun KeywordSetSection(myPageState: MyPageState, onAddBtnClick: () -> Unit) {
                 modifier = Modifier.height(32.dp),
                 horizontalArrangement = Arrangement.spacedBy(10.dp)
             ) {
-                keywordList?.forEach { keyword ->
+                keywordList.forEach { keyword ->
                     InputChip(
                         modifier = Modifier.clip(RoundedCornerShape(20.dp)),
                         onClick = { },
@@ -100,7 +99,8 @@ fun KeywordSetSection(myPageState: MyPageState, onAddBtnClick: () -> Unit) {
                                 modifier = Modifier
                                     .size(12.dp)
                                     .clickable {
-                                        // api call
+                                        Log.d("Retrofit", "keyword = $keyword")
+                                        onCloseBtnClick(keyword)
                                     }
                             )
                         },
@@ -137,5 +137,5 @@ fun KeywordSetSection(myPageState: MyPageState, onAddBtnClick: () -> Unit) {
 @Preview
 @Composable
 fun KeywordPreview() {
-    KeywordSetSection(MyPageState(), {})
+//    KeywordSetSection(listOf()) {}
 }

--- a/app/src/main/java/com/example/mz_focusnews/feature/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/example/mz_focusnews/feature/mypage/MyPageScreen.kt
@@ -1,6 +1,7 @@
 package com.example.mz_focusnews.feature.mypage
 
 import android.util.Log
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -19,6 +20,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
@@ -38,16 +40,38 @@ import com.example.mz_focusnews.core.theme.preFontFamily
 fun MyPageScreen(viewModel: MyPageViewModel, navController: NavController) {
 
     val mypageState = viewModel.mypageState.collectAsState().value
+    val setKeywordState = viewModel.setKeywordState.collectAsState().value
+    val delKeywordState = viewModel.delKeywordState.collectAsState().value
 
     var alarmChecked by remember { mutableStateOf(true) }
     var locationChecked by remember { mutableStateOf(false) }
 
     var openDialog by remember { mutableStateOf(false) }
 
+    val context = LocalContext.current
+
     LaunchedEffect(mypageState.mypageInfo) {
         mypageState.mypageInfo?.let { info ->
             alarmChecked = info.alarm
             locationChecked = info.location
+        }
+    }
+
+    // 등록 성공 시 Toast
+    LaunchedEffect(setKeywordState.isError) {
+        when (setKeywordState.isError) {
+            false -> Toast.makeText(context, "키워드를 등록했어요! ☺️", Toast.LENGTH_SHORT).show()
+            true -> Toast.makeText(context, "키워드를 등록하지 못했어요 🥹", Toast.LENGTH_SHORT).show()
+            null -> {}
+        }
+    }
+
+    // 삭제 성공 시 Toast
+    LaunchedEffect(delKeywordState.isError) {
+        when (delKeywordState.isError) {
+            false -> Toast.makeText(context, "키워드를 삭제했어요! ☺️", Toast.LENGTH_SHORT).show()
+            true -> Toast.makeText(context, "키워드를 삭제하지 못했어요 🥹", Toast.LENGTH_SHORT).show()
+            null -> {}
         }
     }
 
@@ -97,14 +121,16 @@ fun MyPageScreen(viewModel: MyPageViewModel, navController: NavController) {
                             Log.d("Retrofit", "${mypageState.mypageInfo.id}, $keyword")
                             viewModel.delUserKeyword(mypageState.mypageInfo.id, keyword)
                         },
-                        onAddBtnClick = { openDialog = true })
+
+                        onAddBtnClick = { openDialog = true }
+                    )
 
                     NavItemBox(
-                        "최근 본 뉴스",
+                        title = "최근 본 뉴스",
                         onClick = { navController.navigate("recent/${mypageState.mypageInfo.id}") })
 
                     NavItemBox(
-                        "내가 좋아하는 뉴스",
+                        title = "내가 좋아하는 뉴스",
                         onClick = { navController.navigate("like/${mypageState.mypageInfo.id}") })
 
                     ToggleItemBox(

--- a/app/src/main/java/com/example/mz_focusnews/feature/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/example/mz_focusnews/feature/mypage/MyPageScreen.kt
@@ -1,5 +1,6 @@
 package com.example.mz_focusnews.feature.mypage
 
+import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -40,7 +41,6 @@ fun MyPageScreen(viewModel: MyPageViewModel, navController: NavController) {
 
     var alarmChecked by remember { mutableStateOf(true) }
     var locationChecked by remember { mutableStateOf(false) }
-
 
     var openDialog by remember { mutableStateOf(false) }
 
@@ -91,11 +91,21 @@ fun MyPageScreen(viewModel: MyPageViewModel, navController: NavController) {
 
                     QuizScoreSection()
 
-                    KeywordSetSection(mypageState, onAddBtnClick = { openDialog = true })
+                    KeywordSetSection(
+                        keyword = mypageState.mypageInfo.keyword,
+                        onCloseBtnClick = { keyword ->
+                            Log.d("Retrofit", "${mypageState.mypageInfo.id}, $keyword")
+                            viewModel.delUserKeyword(mypageState.mypageInfo.id, keyword)
+                        },
+                        onAddBtnClick = { openDialog = true })
 
-                    NavItemBox("최근 본 뉴스", onClick = { navController.navigate("recent/${mypageState.mypageInfo.id}") })
+                    NavItemBox(
+                        "최근 본 뉴스",
+                        onClick = { navController.navigate("recent/${mypageState.mypageInfo.id}") })
 
-                    NavItemBox("내가 좋아하는 뉴스", onClick = { navController.navigate("like/${mypageState.mypageInfo.id}") })
+                    NavItemBox(
+                        "내가 좋아하는 뉴스",
+                        onClick = { navController.navigate("like/${mypageState.mypageInfo.id}") })
 
                     ToggleItemBox(
                         title = "속보 알림 수신 동의",
@@ -128,9 +138,10 @@ fun MyPageScreen(viewModel: MyPageViewModel, navController: NavController) {
         if (openDialog) {
             AddKeywordDialog(
                 onDismiss = { openDialog = false },
-                onKeywordAdded = {
-
-                })
+                onKeywordAdded = { prev, new ->
+                    mypageState.mypageInfo?.let { viewModel.setUserKeyword(it.id, prev, new) }
+                }
+            )
         }
     }
 }

--- a/app/src/main/java/com/example/mz_focusnews/feature/mypage/MyPageViewModel.kt
+++ b/app/src/main/java/com/example/mz_focusnews/feature/mypage/MyPageViewModel.kt
@@ -109,12 +109,12 @@ data class MyPageState(
 
 data class SetKeywordState(
     val isLoading: Boolean = false,
-    val isError: Boolean = false,
+    val isError: Boolean? = null,
     val errorMsg: String? = null
 )
 
 data class DelKeywordState(
     val isLoading: Boolean = false,
-    val isError: Boolean = false,
+    val isError: Boolean? = null,
     val errorMsg: String? = null
 )

--- a/app/src/main/java/com/example/mz_focusnews/feature/mypage/MyPageViewModel.kt
+++ b/app/src/main/java/com/example/mz_focusnews/feature/mypage/MyPageViewModel.kt
@@ -3,7 +3,9 @@ package com.example.mz_focusnews.feature.mypage
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.mz_focusnews.core.api.model.DelKeywordRequest
 import com.example.mz_focusnews.core.api.model.MyPageInfo
+import com.example.mz_focusnews.core.api.model.SetKeywordRequest
 import com.example.mz_focusnews.core.api.service.ApiService
 import com.example.mz_focusnews.core.api.service.RetrofitClient
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -16,6 +18,12 @@ class MyPageViewModel : ViewModel() {
     private val _mypageState = MutableStateFlow(MyPageState())
     val mypageState: StateFlow<MyPageState> = _mypageState
 
+    private val _setKeywordState = MutableStateFlow(SetKeywordState())
+    val setKeywordState: StateFlow<SetKeywordState> = _setKeywordState
+
+    private val _delKeywordState = MutableStateFlow(DelKeywordState())
+    val delKeywordState: StateFlow<DelKeywordState> = _delKeywordState
+
     init {
         fetchMyPageInfo()
     }
@@ -26,19 +34,86 @@ class MyPageViewModel : ViewModel() {
         viewModelScope.launch {
             try {
                 val response = service.getMyPageInfo()
-                _mypageState.value = MyPageState(mypageInfo = response.data, isLoading = false, isError = false)
+                _mypageState.value =
+                    MyPageState(mypageInfo = response.data, isLoading = false, isError = false)
 
                 Log.d("Retrofit", "fetchMyPageInfo called:: ${_mypageState.value}")
             } catch (e: Exception) {
-                _mypageState.value = MyPageState(isLoading = false, isError = true, errorMsg = e.message)
+                _mypageState.value =
+                    MyPageState(isLoading = false, isError = true, errorMsg = e.message)
                 Log.e("Retrofit", "MyPage Info Error: ${_mypageState.value.errorMsg}")
             }
         }
+    }
+
+    fun setUserKeyword(id: Long, prevKeyword: String, newKeyword: String) {
+        _setKeywordState.value = SetKeywordState(isLoading = true)  // 로딩 시작
+
+        viewModelScope.launch {
+            try {
+                service.setUserKeyword(
+                    SetKeywordRequest(
+                        id = id,
+                        previousKeyword = prevKeyword,
+                        newKeyword = newKeyword
+                    )
+                )
+
+                _setKeywordState.value = SetKeywordState(isLoading = false, isError = false)
+
+                fetchMyPageInfo()
+
+                Log.d("Retrofit", "setKeyword called:: ${_setKeywordState.value}")
+            } catch (e: Exception) {
+                _setKeywordState.value =
+                    SetKeywordState(isLoading = false, isError = true, errorMsg = e.message)
+                Log.e("Retrofit", "Set Keyword Error: ${_setKeywordState.value.errorMsg}")
+            }
+        }
+    }
+
+    fun delUserKeyword(userId: Long, keyword: String) {
+        _delKeywordState.value = DelKeywordState(isLoading = true)  // 로딩 시작
+
+        viewModelScope.launch {
+            try {
+                service.deleteUserKeyword(
+                    DelKeywordRequest(
+                        userId = userId,
+                        keyword = keyword
+                    )
+                )
+
+                _delKeywordState.value = DelKeywordState(isLoading = false, isError = false)
+
+                fetchMyPageInfo()
+
+                Log.d("Retrofit", "delKeyword called:: ${_delKeywordState.value}")
+
+            } catch (e: Exception) {
+                _delKeywordState.value =
+                    DelKeywordState(isLoading = false, isError = true, errorMsg = e.message)
+                Log.e("Retrofit", "Delete Keyword Error: ${_delKeywordState.value.errorMsg}")
+            }
+        }
+
     }
 }
 
 data class MyPageState(
     val mypageInfo: MyPageInfo? = null,
+    val isLoading: Boolean = false,
+    val isError: Boolean = false,
+    val errorMsg: String? = null
+)
+
+data class SetKeywordState(
+    val isLoading: Boolean = false,
+    val isError: Boolean = false,
+    val errorMsg: String? = null
+)
+
+data class DelKeywordState(
     val isLoading: Boolean = false,
     val isError: Boolean = false,
     val errorMsg: String? = null


### PR DESCRIPTION
## ✒️ 관련 이슈번호
Closes #21 

## Key Changes 🔑
- 서버의 weather 응답 값 변경에 따른 이미지 매핑 수정
- ContentScreen의 연관 뉴스 안내 문구 문맥에 맞게 수정
- 키워드 등록 API 연동
- 키워드 삭제 API 연동
- 성공/실패에 따라 사용자에게 Toast 띄우기

## 🚧 TODO  
현재는 키워드 등록/삭제 시 마이페이지 정보 API를 다시 호출해 키워드 리스트를 갱신하고 있음  
추후 키워드를 따로 로컬에서도 관리할 예정 → #22 에서 해결
